### PR TITLE
Fix indents in xencontrol.c

### DIFF
--- a/build.py
+++ b/build.py
@@ -184,7 +184,7 @@ def shell(command, dir):
                            stderr=subprocess.STDOUT)
 
     for line in sub.stdout:
-        print(line.decode(sys.getdefaultencoding()).rstrip())
+        print(line.decode(sys.stdout.encoding).rstrip())
 
     sub.wait()
 

--- a/src/xencontrol/xencontrol.c
+++ b/src/xencontrol/xencontrol.c
@@ -501,18 +501,18 @@ XcGnttabRevokeForeignAccess(
                               NULL);
 
     if (!Success) {
-		Status = GetLastError();
+        Status = GetLastError();
         Log(XLL_ERROR, L"IOCTL_XENIFACE_GNTTAB_UNGRANT_PAGES failed");
         goto fail;
     } else {
-		/*
-		 * [pcfist@gmail.com]
-		 * Don't check GetLastError() on success because DeviceIoControl()
-		 * does not change it when succeeds so we might end up returning stale
-		 * error code value to client when the call is really successful.
-		 */
-		Status = ERROR_SUCCESS;
-	}
+        /*
+         * [pcfist@gmail.com]
+         * Don't check GetLastError() on success because DeviceIoControl()
+         * does not change it when succeeds so we might end up returning stale
+         * error code value to client when the call is really successful.
+         */
+        Status = ERROR_SUCCESS;
+    }
 
     EnterCriticalSection(&Xc->RequestListLock);
     RemoveEntryList(&Request->ListEntry);
@@ -642,13 +642,13 @@ XcGnttabUnmapForeignPages(
                               &Returned,
                               NULL);
 
-	if (!Success) {
-		Status = GetLastError();
+    if (!Success) {
+        Status = GetLastError();
         Log(XLL_ERROR, L"IOCTL_XENIFACE_GNTTAB_UNMAP_FOREIGN_PAGES failed");
         goto fail;
     } else {
-		Status = ERROR_SUCCESS;
-	}
+        Status = ERROR_SUCCESS;
+    }
 
     EnterCriticalSection(&Xc->RequestListLock);
     RemoveEntryList(&Request->ListEntry);

--- a/vs2013/xencontrol-test/xencontrol-test.vcxproj
+++ b/vs2013/xencontrol-test/xencontrol-test.vcxproj
@@ -35,6 +35,18 @@
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <PlatformToolset>v120</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <PlatformToolset>v120</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <PlatformToolset>v120</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <PlatformToolset>v120</PlatformToolset>
+  </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />

--- a/vs2013/xencontrol.props
+++ b/vs2013/xencontrol.props
@@ -15,7 +15,6 @@
 
   <PropertyGroup Label="Configuration">
     <LinkIncremental>false</LinkIncremental>
-    <PlatformToolset>v120</PlatformToolset>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">

--- a/vs2013/xencontrol.props
+++ b/vs2013/xencontrol.props
@@ -6,7 +6,7 @@
   <PropertyGroup Label="UserMacros" />
 
   <PropertyGroup>
-    <IncludePath>$(SolutionDir)\..\include;$(IncludePath)</IncludePath>
+    <IncludePath>$(ProjectDir)..\..\include;$(IncludePath)</IncludePath>
     <LibraryPath>$(SolutionDir)\$(Configuration)\$(Platform);$(LibraryPath)</LibraryPath>
     <OutDir>$(SolutionDir)\$(Configuration)\$(Platform)\</OutDir>
     <IntDir>$(SolutionDir)\$(ProjectName)\$(Configuration)\$(Platform)\</IntDir>

--- a/vs2013/xencontrol/xencontrol.vcxproj
+++ b/vs2013/xencontrol/xencontrol.vcxproj
@@ -28,6 +28,18 @@
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <PlatformToolset>v120</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <PlatformToolset>v120</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <PlatformToolset>v120</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <PlatformToolset>v120</PlatformToolset>
+  </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />


### PR DESCRIPTION
Replaced tabs with spaces to match surrounding code (fix for 4cee27cdaa088ec9758082f2fb91aa290feaf19f).
